### PR TITLE
Make the .env file optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 
 PROJECTNAME=$(shell basename "$(PWD)")
 


### PR DESCRIPTION
this way `make` won't fail if the `.env` file is missing.